### PR TITLE
Extension by HMI-, ADAS- and Dynamic-Values

### DIFF
--- a/osi_adas_function.proto
+++ b/osi_adas_function.proto
@@ -1,0 +1,112 @@
+syntax = "proto2";
+
+option optimize_for = SPEED;
+
+import "osi_common.proto";
+import "osi_common_extension.proto";
+
+package osi3;
+
+//
+// \brief An Interface to describe the communication of an ADAS-function.
+// This proto is in far parts complementary to the osi_driver_inputs.proto.
+// The inputs are divided into states and requests.
+//
+// The first set of signals are states the function sets internally
+// and are relevant for the vehicle state.
+//
+message FunctionStates
+{
+    // States of an ADAS-Function (SAE Level 3).
+    //
+    optional AdasSAELevel3 adas_sae_level_3 = 1;
+
+	// States of the longitudinal control.
+    //
+    optional LongitudinalControl longitudinal_control = 2;
+
+	// States of the lateral control.
+    //
+    optional LateralControl lateral_control = 3;
+
+	// States of function Emergency-Brake-Assistant.
+    //
+    optional EmergencyBrakeAssistant emergency_brake_assistant = 4;
+
+	// State of an ADAS-Function (SAE Level 3).
+    //
+    optional bool pilot_level3_state = 5;
+
+	// Request that the driver has to take over.
+	// 0=Off; 1=On
+    //
+    optional bool driver_take_over_request = 6;
+
+	// Color of the steering wheel (e.g. to show the driving mode).
+	// See osi_common_extension.
+	// 
+    optional ColorformatRGB steering_wheel_lighting_color = 7;
+
+	// Requested state of the blindspot-lights (often in the side mirrors).
+    //
+    enum BlindSpotWarning
+    {
+        NONE = 0;
+
+        LEFT = 1;
+
+		RIGHT = 2;
+
+		BOTH = 3;
+	}
+}
+
+//
+// \brief An Interface to describe the communication of an ADAS-function.
+// This proto is in far parts complementary to the osi_driver_inputs.proto.
+// The inputs are divided into states and requests.
+//
+// The first set of signals are states the function sets internally
+// and are relevant for the vehicle state.
+//
+message FunctionRequests
+{
+	// All information about the trajectory the vehicle should follow.
+	// See osi_common_extension.
+    //
+    optional Trajectory trajectory = 1;
+
+	// Angle, angle-speed and torque.
+	// See osi_common_extension.
+    //
+    optional Steeringwheel steeringwheel = 2;
+
+	// Factor to scale the steeringtorque of the function output.
+	// 0-1 (0 = no force of the function, 0.5 = half the force, 1 = 100% Torque).
+    //
+    optional double steering_override_factor = 3;
+
+	// Acceleration-, brakepedal and clutch.
+	// See osi_common_extension.
+    //
+    optional Pedalry pedalry = 4;
+
+	// Position of the handbrake.
+	// 0-100 (percentage of position: Released - fully pressed)
+    //
+    optional double handbrake = 5;
+	
+	// This is a description of the possible indicatorstates.
+	//
+	enum Indicators
+	{
+		NONE = 0;
+
+		LEFT = 1;
+
+		RIGHT = 2;
+
+		// Warning lights.
+		ALL = 3;
+	}	
+}

--- a/osi_common_extension.proto
+++ b/osi_common_extension.proto
@@ -1,0 +1,278 @@
+syntax = "proto2";
+
+option optimize_for = SPEED;
+
+package osi3;
+
+//
+// \brief A description for the steeringwheel.
+//
+message Steeringwheel
+{
+    // Angle of the steeringwheel. 
+	//
+	// Unit in Rad [-pi, pi]: 0=Central (Straight); Left>0; 0>Right.
+    //
+    optional double angle = 1;
+
+    // Angle-speed of the steeringwheel.
+	//
+	// Unit in rad/s [-pi/s, pi/s]: 0=Central (Straight); Left>0; 0>Right.
+    //
+    optional double anglespeed = 2;
+
+    // Torque of the steeringwheel to the hand.
+	//
+	// Unit in Nm: 0=Central (Straight); Left>0; 0>Right.
+    //
+    optional double torque = 3;
+}
+
+//
+// \brief A description for the positions of the pedals.
+//
+//
+message Pedalry
+{
+	// Position of the acceleration-pedal.
+	// 0-100 (percentage of position: Unpressed - fully pressed)
+    //
+    optional double pedalposition_acceleration = 1;
+
+	// Position of the brake-pedal.
+	// 0-100 (percentage of position: Unpressed - fully pressed)
+    //
+    optional double pedalposition_brake = 2;
+	
+	// Position of the clutch-pedal.
+	// 0-100 (percentage of position: Unpressed - fully pressed)
+    //
+    optional double pedalposition_clutch = 3;
+}
+
+//
+// \brief This is a message to describe, which trajectory the vehicle should follow.
+//
+//
+message Trajectory
+{
+	// Contains the timestamp where the trajectorypoint should be reached.
+	// In [s].
+    //
+    optional double timestamp = 1;
+	
+	// Contains the X-Position the vehicle should be at the timestamp.
+    //
+    optional double targeted_PosX = 2;
+
+	// Contains the Y-Position the vehicle should be at the timestamp.
+    //
+    optional double targeted_PosY = 3;
+
+	// Direction of the vehicle at the timestamp.
+	// In [Rad].
+    //
+    optional double trackangle = 4;
+
+	// Contains the curvature at the timestamp.
+	// In [1/m].
+    //
+    optional double curvature = 5;
+
+	// Contains the curvaturechange at the timestamp.
+	// In [1/m*s].
+    //
+    optional double curvaturechange = 6;
+
+	// Contains the velocity of the vehicle at the timestamp.
+	// In [m/s].
+    //
+    optional double velocity = 7;
+
+	// Contains the acceleration of the vehicle at the timestamp.
+	// In [m/s^2].
+    //
+    optional double acceleration = 8;
+
+	// Contains the interpolation method.
+    //
+    enum interpolation_method
+    {
+        // Stay on the actual lane.
+        //
+        LINEAR = 0;
+
+        // Change to the left.
+        //
+        CUBIC = 1;
+	}
+}
+
+//
+// \brief This is a description of possible gears.
+//
+//
+message Gear
+{
+	// The actual gear of the car.
+    //
+    enum Gear
+    {
+        // The actual gear was not calculated by the dynamicmodell.
+        //
+        GEAR_UNKNOWN = 0;
+
+        // The actual gear is 1.
+        //
+        GEAR_1 = 1;
+
+        // The actual gear is 2.
+        //
+        GEAR_2 = 2;
+
+		// The actual gear is 3.
+        //
+        GEAR_3 = 3;
+
+		// The actual gear is 4.
+        //
+        GEAR_4 = 4;
+
+        // The actual gear is 5.
+        //
+        GEAR_5 = 5;
+
+		// The actual gear is 6.
+        //
+        GEAR_6 = 6;
+
+		// The actual gear is 7.
+        //
+        GEAR_7 = 7;
+
+        // The actual gear is 8.
+        //
+        GEAR_8 = 8;
+
+		// The actual gear is 9.
+        //
+        GEAR_9 = 9;
+		
+		// The car is in idling-mode.
+        //
+        GEAR_IDLING = 10;
+
+		// The car is in reverse-mode.
+        //
+        GEAR_REVERSE = 11;
+
+		// The car is in automatic-driving-mode.
+        //
+        GEAR_D = 20;
+
+		// The car is in automatic-idling-mode.
+        //
+        GEAR_N = 21;
+
+		// The car is in automatic-parking-mode.
+        //
+        GEAR_P = 22;
+
+		// The car has an automatic transmission, but the driver shifts up by his own.
+        //
+        GEAR_Up = 30;
+
+		// The car has an automatic transmission, but the driver shifts by his own.
+        //
+        GEAR_MID = 31;
+
+		// The car has an automatic transmission, but the driver shifts down by his own.
+        //
+        GEAR_DOWN = 32;
+	}
+}
+
+//
+// \brief A 3D-vector for color-description regarding the RGB-format.
+// More information: https://en.wikipedia.org/wiki/RGB_color_model.
+//
+message ColorformatRGB
+{
+	// The part of red.
+	// Values from 0 to 255.
+    //
+    optional uint32 rgb_red = 1;
+
+	// The part of green.
+	// Values from 0 to 255.
+    //
+    optional uint32 rgb_green = 2;
+	
+	// The part of blue.
+	// Values from 0 to 255.
+    //
+    optional uint32 rgb_blue = 3;
+}
+
+//
+// \brief A description for highly automated driving (SAE Level 3).
+//
+//
+message AdasSAELevel3
+{
+	// Activationstate of the function.
+    //
+    optional bool is_activated = 1;
+
+	// This is the speed the function targets.
+	// E.g.: At the point of activation, the actual speed could be 80 km/h, 
+	// but the function tries to accelerate to 130 km/h.
+	// In [km/h].
+    //
+    optional double targeted_speed = 2;
+}
+
+//
+// \brief A description for the function longitudinal control.
+//
+//
+message LongitudinalControl
+{
+	// Activationstate of the function.
+    //
+    optional bool is_activated = 1;
+
+	// This is the speed the function targets.
+	// E.g.: At the point of activation, the actual speed could be 80 km/h, 
+	// but the function tries to accelerate to 130 km/h.
+	// In [km/h].
+    //
+    optional double targeted_speed = 2;
+
+	// The timegap describes the minimumdistance to the next vehicle in front.
+	// In [s].
+    //
+    optional bool timegap = 3;
+}
+
+//
+// \brief A description for the function lateral control.
+//
+//
+message LateralControl
+{
+	// Activationstate of the function.
+    //
+    optional bool is_activated = 1;
+}
+
+//
+// \brief A description for the function emergency brake assistant.
+//
+//
+message EmergencyBrakeAssistant
+{
+	// Activationstate of the function.
+    //
+    optional bool is_activated = 1;
+}

--- a/osi_driver_inputs.proto
+++ b/osi_driver_inputs.proto
@@ -1,0 +1,109 @@
+syntax = "proto2";
+
+option optimize_for = SPEED;
+
+import "osi_common.proto";
+import "osi_common_extension.proto";
+
+package osi3;
+
+//
+// \brief An Interface to describe the inputs from a human driver.
+// Contains a base-set of signals with focus on ADAS-functions.
+// The inputs are divided into states and requests.
+//
+// The first set of signals are states the driver can (usually) directly set.
+//
+message DriverInitializedStates
+{
+	// State of the driver seat-belt. It is often an initial condition to start an ADAS-Function.
+	// 0=Open; 1=Closed
+    //
+    optional bool seat_belt = 1;
+
+	// State of the doors. It is often an initial condition to start an ADAS-Function.
+	// 0=Open; 1=Closed
+    //
+    optional bool doors = 2;
+
+	// Hands-On-Detection.
+	// 0=HandsOff; 1=HandsOn
+    //
+    optional bool hands_on_detection = 3;
+
+	// State of the ignition. It is often an initial condition to start an ADAS-Function.
+	// 0=Off; 1=On
+    //
+    optional bool ignition = 4;
+
+	// State of the warning lights.
+	// 0=Off; 1=On
+    //
+    optional bool warning_lights = 5;
+
+	// Angle, angle-speed and torque.
+	// See osi_common_extension.
+    //
+    optional Steeringwheel steeringwheel = 6;
+
+	// Acceleration-, brakepedal and clutch.
+	// See osi_common_extension.
+    //
+    optional Pedalry pedalry = 7;
+
+	// Position of the handbrake.
+	// 0-100 (percentage of position: Released - fully pressed)
+    //
+    optional double handbrake = 8;
+	
+	// Position of the gearlever.
+	// See osi_common_extension.
+    //
+    optional Gear gearlever = 9;
+}
+
+// 
+// The second set of signals are requests addressed to an external function.
+// The ADAS-function can react to a request by setting its own states.
+// The osi_adas_function.proto is widely complementary to this proto.
+// For e.g. the driver wants to activate a function, but the initial-conditions of the
+// ADAS-function are not fullfilled, the request is without an effect to the driving behaviour.
+//
+message DriverRequests
+{	
+	// Wished states of the driver regarding an ADAS-Function (SAE Level 3).
+    //
+    optional AdasSAELevel3 adas_sae_level_3 = 1;
+
+	// Wished states of the driver regarding the longitudinal control.
+    //
+    optional LongitudinalControl longitudinal_control = 2;
+
+	// Wished states of the driver regarding the lateral control.
+    //
+    optional LateralControl lateral_control = 3;
+
+	// Wished states of the driver regarding the function Emergency-Brake-Assistant.
+    //
+    optional EmergencyBrakeAssistant emergency_brake_assistant = 4;
+
+	// Request to an ADAS-Function for a lane change.
+	// 0=EgoLane; 1=Left; 2=Right
+    //
+    enum lane_change_request
+    {
+        // Stay on the actual lane.
+        //
+        EGO_LANE = 0;
+
+        // Change to the left.
+        //
+        LC_LEFT = 1;
+
+		// Change to the right.
+        //
+        LC_RIGHT = 2;
+	}
+}
+
+

--- a/osi_environment_extension.proto
+++ b/osi_environment_extension.proto
@@ -1,0 +1,45 @@
+syntax = "proto2";
+
+option optimize_for = SPEED;
+
+package osi3;
+
+//
+// \brief Interface for the description of the environment.
+// Can be used as Input for a dynamicmodel (also known as VehicleModell or ISARModell).
+//
+message Environment
+{
+	// Contains the friction-coefficient of each wheel.
+	// Dimensionless.
+	//
+	optional double friction_coefficient_frontleft = 1;
+	optional double friction_coefficient_frontright = 2;
+	optional double friction_coefficient_rearleft = 3;
+	optional double friction_coefficient_rearright = 4;
+
+	// Contains the z-coordinate (contact-point) of each wheel.
+	// Dimensionless.
+	//
+	optional double tyre_contact_point_frontleft = 5;
+	optional double tyre_contact_point_frontright = 6;
+	optional double tyre_contact_point_rearleft = 7;
+	optional double tyre_contact_point_rearright = 8;
+
+	// Contains the ambienttemperature.
+	// In [K].
+	//
+	optional double ambienttemperature = 9;
+
+	// Contains the velocity of the wind.
+	// In [m/s].
+	//
+	optional double windvelocity = 10;
+	
+	// Contains the direction of the wind.
+	// In [°]. Wind direction is measured in degrees clockwise from due north.
+	// E.g.: A wind blowing from the north has a wind direction of 0°.
+	// More information: https://en.wikipedia.org/wiki/Wind_direction
+	//
+	optional double winddirection = 11;
+}

--- a/osi_vehicle.proto
+++ b/osi_vehicle.proto
@@ -1,0 +1,156 @@
+syntax = "proto2";
+
+option optimize_for = SPEED;
+
+import "osi_common.proto";
+import "osi_common_extension.proto";
+
+package osi3;
+
+//
+// \brief Interface for the output of a dynamicmodel (also known as vehiclemodell).
+// Contains a base-set of signals that can be used by a simulation-environment.
+//
+// Consists of three messages: DynamicKinematics, DynamicPowertrain and DynamicSteering.
+//
+// All coordinates and orientations are relative to the global ground truth
+// coordinate system.
+//
+message VehicleKinematics
+{
+    // The 3D dimension of the moving object (its bounding box).
+    //
+    optional Dimension3d dimension = 1;
+
+    // The reference point for position and orientation: the center (x,y,z) of
+    // the bounding box.
+    //
+    optional Vector3d position = 2;
+
+    // The relative velocity of the moving object w.r.t. its parent frame and
+    // parent velocity.
+    // The velocity becomes global/absolute if the parent frame does not move.
+    //
+    // <tt>#position (t) := #position (t-dt)+ #velocity *dt</tt>
+    //
+    optional Vector3d velocity = 3;
+
+    // The relative acceleration of the moving object w.r.t. its parent frame
+    // and parent acceleration.
+    // The acceleration becomes global/absolute if the parent frame is not
+    // accelerating.
+    //
+    // <tt> #position (t) := #position (t-dt)+ #velocity *dt+ #acceleration /2*dt^2</tt>
+    //
+    // <tt> #velocity (t) := #velocity (t-dt)+ #acceleration *dt</tt>
+    //
+    optional Vector3d acceleration = 4;
+
+	// The relative orientation of the moving object w.r.t. its parent frame.
+    //
+    // <tt>Origin_base_moving_entity := Rotation_yaw_pitch_roll(#orientation)*(Origin_parent_coordinate_system - #position)</tt>
+    //
+    // \note There may be some constraints how to align the orientation w.r.t.
+    // to some stationary object's or entity's definition.
+    //
+    optional Orientation3d orientation = 5;
+
+    // The relative orientation rate of the moving object w.r.t. its parent
+    // frame and parent orientation rate in the center point of the bounding box
+    // (origin of the bounding box frame).
+    //
+    // <tt>Rotation_yaw_pitch_roll(#orientation (t)) := Rotation_yaw_pitch_roll(#orientation_rate *dt)*Rotation_yaw_pitch_roll(#orientation (t-dt))</tt>
+    //
+    // \note <tt>#orientation (t)</tt> is \b not equal <tt>#orientation (t-dt)+#orientation_rate *dt</tt>
+    //
+    optional Orientation3d orientation_rate = 6;
+
+	// The relative orientation rate acceleration of the moving object w.r.t. its parent
+    // frame and parent orientation rate in the center point of the bounding box
+    // (origin of the bounding box frame).
+    //
+    // <tt>Rotation_yaw_pitch_roll(#orientation (t)) := Rotation_yaw_pitch_roll(#orientation_rate *dt)*Rotation_yaw_pitch_roll(#orientation (t-dt))</tt>
+    //
+    // \note <tt>#orientation (t)</tt> is \b not equal <tt>#orientation (t-dt)+#orientation_rate *dt</tt>
+    //
+    optional Orientation3d orientation_rate_acceleration = 7;
+}
+
+message VehiclePowertrain
+{
+    // Rounds per minute of the crankshaft.
+    //
+    optional double engine_rpm = 1;
+
+	// Torque in Nm.
+    //
+    optional double engine_torque = 2;
+
+	// Consumption in liters per 100 km.
+    //
+    optional double engine_consumption = 3;
+
+	// The actual gear of the car.
+    //
+    optional Gear gear = 4;
+}
+
+message VehicleSteeringwheel
+{
+	// Angle, angle-speed and torque.
+	// See osi_common_extension.
+    //
+    optional Steeringwheel steeringwheel = 1;
+
+    // Spring-stiffness of the steering in Nm/°.
+    //
+    optional double stw_springstiffness = 2;
+
+    // Damping of the steering in Nm*s/°.
+    //
+    optional double stw_damping = 3;
+
+    // Friction of the steering in Nm.
+    //
+    optional double stw_friction = 4;
+}
+
+message VehicleWheels
+{
+	// Contains the rotational speed of each wheel per second.
+	// In [Rad/s].
+	optional double speed_frontleft = 1;
+	optional double speed_frontright = 2;
+	optional double speed_rearleft = 3;
+	optional double speed_rearright = 4;
+
+	// Contains the steering angle of each wheel.
+	// In [Rad].
+	optional double steeringangle_frontleft = 5;
+	optional double steeringangle_frontright = 6;
+	optional double steeringangle_rearleft = 7;
+	optional double steeringangle_rearright = 8;
+
+	// Contains the camber of each wheel.
+	// In [Rad].
+	// Negative camber if the bottom of the wheel is farther out than the top.
+	// For more information: https://en.wikipedia.org/wiki/Camber_angle
+	optional double camber_frontleft = 9;
+	optional double camber_frontright = 10;
+	optional double camber_rearleft = 11;
+	optional double camber_rearright = 12;
+
+	// Contains the tirepressure of each tire.
+	// In [Pascal].
+	optional double tirepressure_frontleft = 13;
+	optional double tirepressure_frontright = 14;
+	optional double tirepressure_rearleft = 15;
+	optional double tirepressure_rearright = 16;
+
+	// Contains the springdeflection in z-direction for each wheel.
+	// In [mm].
+	optional double springdeflection_frontleft = 17;
+	optional double springdeflection_frontright = 18;
+	optional double springdeflection_rearleft = 19;
+	optional double springdeflection_rearright = 20;
+}


### PR DESCRIPTION
Think about a simulation-construct consisting of a human driver, an AD-function and also a dynamic-model.
All these pieces can come from different authors, but should work together.
This is a requirement the driving-simulation-sector has to deal with:

A test person wants to activate an external highly automated driving in a mock-up. So the function has to listen to the mock-up. The other way around the mock-up has to understand commands from the function (Take-over-request?). So this  is an interface that should be standardized.
Furthermore, it is the same with an external dynamic-model. How can this listen to the simulation-environment to get values like the friction of the street needed for dynamic-calculations? And also here, the other way around: The results of the dynamic-model describe the state of a vehicle regarding kinematics. Additionally, calculated values for the engine or the steering can be part of. Both datasets are worth to be standardized.

Dear OSI-Community, please help to enhance the appended .proto-signals.